### PR TITLE
Improve Kubernetes Provider Tests

### DIFF
--- a/condition/condition_test.go
+++ b/condition/condition_test.go
@@ -3,7 +3,7 @@ package condition
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetArguments(t *testing.T) {
@@ -23,12 +23,12 @@ func TestGetArguments(t *testing.T) {
 	for _, c := range cases {
 		result, err := getArguments(c.argString, c.expectedCount)
 		if c.expectsError {
-			assert.Error(t, err)
+			require.Error(t, err)
 		} else {
-			assert.NoError(t, err)
-			assert.Equal(t, len(c.expected), len(result))
+			require.NoError(t, err)
+			require.Equal(t, len(c.expected), len(result))
 			for i := range c.expected {
-				assert.Equal(t, c.expected[i], result[i])
+				require.Equal(t, c.expected[i], result[i])
 			}
 		}
 	}
@@ -60,12 +60,12 @@ func TestNewCondition(t *testing.T) {
 	for _, c := range cases {
 		condition, err := NewCondition(c.conditionString)
 		if c.expectError {
-			assert.Error(t, err)
+			require.Error(t, err)
 		} else {
-			assert.NoError(t, err)
-			assert.Equal(t, c.expectedType, condition.Type)
-			assert.Equal(t, c.expectedType.expectedArgsCount(), uint(len(condition.Args)))
-			assert.Equal(t, c.expectedArgs, condition.Args)
+			require.NoError(t, err)
+			require.Equal(t, c.expectedType, condition.Type)
+			require.Equal(t, c.expectedType.expectedArgsCount(), uint(len(condition.Args)))
+			require.Equal(t, c.expectedArgs, condition.Args)
 		}
 	}
 }
@@ -90,16 +90,16 @@ func TestApplyCondition(t *testing.T) {
 	for _, c := range cases {
 		condition, err := NewCondition(c.conditionString)
 		if c.expectError {
-			assert.Error(t, err)
+			require.Error(t, err)
 		} else {
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		}
 
 		for _, successTest := range c.successInputs {
-			assert.True(t, condition.ApplyCondition(successTest))
+			require.True(t, condition.ApplyCondition(successTest))
 		}
 		for _, failTest := range c.failInputs {
-			assert.False(t, condition.ApplyCondition(failTest))
+			require.False(t, condition.ApplyCondition(failTest))
 		}
 	}
 }

--- a/credential-provider/aws_provider.go
+++ b/credential-provider/aws_provider.go
@@ -78,6 +78,6 @@ func (p AwsProvider) GetCredentialWithName(key string) (string, error) {
 	return *result.SecretString, nil
 }
 
-func (p AwsProvider) Shutdown() {
-
+func (p AwsProvider) Close() error {
+	return nil
 }

--- a/credential-provider/credential-provider.go
+++ b/credential-provider/credential-provider.go
@@ -99,5 +99,5 @@ func NewCredentialProvider(id CredentialProviderIdentifier, properties map[strin
 type Provider interface {
 	GetCredentialNames() ([]string, error)
 	GetCredentialWithName(string) (string, error)
-	Shutdown()
+	Close() error
 }

--- a/credential-provider/credential-provider_test.go
+++ b/credential-provider/credential-provider_test.go
@@ -3,18 +3,18 @@ package credential_provider
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCredentialProviderIdentifier_FromString_InvalidString(t *testing.T) {
 	identifier := CredentialProviderIdentifierFromString("Does not exist")
-	assert.Equal(t, CredentialProviderIdentifierInvalid, identifier)
+	require.Equal(t, CredentialProviderIdentifierInvalid, identifier)
 }
 
 func TestCredentialProviderIdentifier_IsValid(t *testing.T) {
 	values := credentialProviderIdentifierValues()
 	for _, val := range values {
-		assert.Equal(t, val != CredentialProviderIdentifierInvalid, val.IsValid())
+		require.Equal(t, val != CredentialProviderIdentifierInvalid, val.IsValid())
 	}
 }
 
@@ -22,11 +22,11 @@ func TestCredentialProviderIdentifier(t *testing.T) {
 	values := credentialProviderIdentifierValues()
 	labels := credentialProviderIdentifierStrings()
 
-	assert.Equal(t, len(values), len(labels))
+	require.Equal(t, len(values), len(labels))
 	for i := range len(values) {
 		fromString := CredentialProviderIdentifierFromString(labels[i])
-		assert.Equal(t, fromString, values[i])
-		assert.Equal(t, uint(i), fromString.Index())
-		assert.Equal(t, fromString.String(), labels[i])
+		require.Equal(t, fromString, values[i])
+		require.Equal(t, uint(i), fromString.Index())
+		require.Equal(t, fromString.String(), labels[i])
 	}
 }

--- a/credential-provider/environment_provider.go
+++ b/credential-provider/environment_provider.go
@@ -43,6 +43,7 @@ func (p EnvironmentProvider) GetCredentialWithName(key string) (string, error) {
 	return val, nil
 }
 
-func (p EnvironmentProvider) Shutdown() {
+func (p EnvironmentProvider) Close() error {
 	// No-op
+	return nil
 }

--- a/credential-provider/environment_provider_test.go
+++ b/credential-provider/environment_provider_test.go
@@ -4,31 +4,34 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWithLoadedEnvironmentVars(t *testing.T) {
-	provider := NewEnvironmentProvider()
-	initialLen := len(provider.GetCredentials())
+	initialProvider := NewEnvironmentProvider()
+	defer initialProvider.Close()
+	initialLen := len(initialProvider.GetCredentials())
 
 	propertyName := "TestWithLoadedEnvironmentVars"
 	propertyValue := "A Value!"
-	_, err := provider.GetCredentialWithName(propertyName)
-	assert.Error(t, err)
+	_, err := initialProvider.GetCredentialWithName(propertyName)
+	require.Error(t, err)
 
 	withLoadedEnvironmentVars(t, map[string]string{propertyName: propertyValue}, func() {
 		newProvider := NewEnvironmentProvider()
-		assert.Greater(t, len(newProvider.GetCredentials()), initialLen)
+		defer newProvider.Close()
+		require.Greater(t, len(newProvider.GetCredentials()), initialLen)
 
 		cred, err := newProvider.GetCredentialWithName(propertyName)
-		assert.NoError(t, err)
-		assert.Equal(t, propertyValue, cred)
+		require.NoError(t, err)
+		require.Equal(t, propertyValue, cred)
 	})
 
-	provider = NewEnvironmentProvider()
+	provider := NewEnvironmentProvider()
+	defer provider.Close()
 	_, err = provider.GetCredentialWithName(propertyName)
-	assert.Error(t, err)
-	assert.Equal(t, initialLen, len(provider.GetCredentials()))
+	require.Error(t, err)
+	require.Equal(t, initialLen, len(provider.GetCredentials()))
 }
 
 func withLoadedEnvironmentVars(t *testing.T, vars map[string]string, testFunc func()) {
@@ -51,5 +54,5 @@ func withLoadedEnvironmentVars(t *testing.T, vars map[string]string, testFunc fu
 		}
 	}
 
-	assert.Equal(t, 0, count)
+	require.Equal(t, 0, count)
 }

--- a/credential-provider/gcp_provider.go
+++ b/credential-provider/gcp_provider.go
@@ -85,8 +85,9 @@ func (p GcpProvider) GetCredentialWithName(key string) (string, error) {
 	return string(result.Payload.Data), nil
 }
 
-func (p GcpProvider) Shutdown() {
-	if err := p.client.Close(); err != nil {
+func (p GcpProvider) Close() (err error) {
+	if err = p.client.Close(); err != nil {
 		fmt.Printf("Failed to close GCP provider with error: [%s].\n", err.Error())
 	}
+	return err
 }

--- a/credential-provider/kubernetes-test-secret.yaml
+++ b/credential-provider/kubernetes-test-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-kubernetes-secret
+type: Opaque
+stringData:
+  credential-name: wow-great-secret

--- a/credential-provider/kubernetes_provider.go
+++ b/credential-provider/kubernetes_provider.go
@@ -70,6 +70,7 @@ func (p KubernetesProvider) GetCredentialWithName(key string) (string, error) {
 	return string(secret.Data[key]), nil
 }
 
-func (p KubernetesProvider) Shutdown() {
+func (p KubernetesProvider) Close() error {
 	// No-op
+	return nil
 }

--- a/credential-provider/kubernetes_provider_test.go
+++ b/credential-provider/kubernetes_provider_test.go
@@ -1,20 +1,38 @@
 package credential_provider
 
 import (
+	"fmt"
+	"os/exec"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+func withSecretConfig(t *testing.T, filepath string, testFunc func()) {
+	cmd := exec.Command("kubectl", "apply", "-f", filepath)
+	output, err := cmd.Output()
+	if err != nil {
+		fmt.Printf("Failed to apply kubernetes config file with path: [%s]. With output [%s]. And error: [%s].", filepath, output, err.Error())
+		t.FailNow()
+		return
+	}
+	// Assuming the configuration was applied correctly with the provided file, I am assuming it will be delete successfully too. For now
+	defer exec.Command("kubectl", "delete", "-f", filepath)
+	testFunc()
+}
+
 func TestKubernetesProvider(t *testing.T) {
-	t.Skip("Skipping since we cannot guarantee the local kubernetes environment is correctly setup")
 	m := make(map[string]interface{})
 	m[property_namespace] = "default"
 	m[property_secret_name] = "my-kubernetes-secret"
-	provider, err := NewKubernetesProvider(m)
-	assert.NoError(t, err)
 
-	val, err := provider.GetCredentialWithName("my-kubernetes-secret")
-	assert.NoError(t, err)
-	assert.NotEmpty(t, val)
+	withSecretConfig(t, "./kubernetes-test-secret.yaml", func() {
+		provider, err := NewKubernetesProvider(m)
+		require.NoError(t, err)
+		defer provider.Close()
+
+		val, err := provider.GetCredentialWithName("credential-name")
+		require.NoError(t, err)
+		require.NotEmpty(t, val)
+	})
 }

--- a/pattern/pattern_test.go
+++ b/pattern/pattern_test.go
@@ -3,7 +3,7 @@ package pattern
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPatternMatches(t *testing.T) {
@@ -21,14 +21,14 @@ func TestPatternMatches(t *testing.T) {
 	for _, c := range cases {
 		pattern, err := NewPattern(c.regex)
 		if c.expectsError {
-			assert.Error(t, err)
+			require.Error(t, err)
 		} else {
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			for _, test := range c.successTests {
-				assert.True(t, pattern.Matches(test))
+				require.True(t, pattern.Matches(test))
 			}
 			for _, test := range c.failTests {
-				assert.False(t, pattern.Matches(test))
+				require.False(t, pattern.Matches(test))
 			}
 		}
 	}

--- a/secrets-validator.go
+++ b/secrets-validator.go
@@ -39,6 +39,6 @@ func main() {
 	}
 
 	for _, provider := range providers {
-		provider.Provider.Shutdown()
+		provider.Provider.Close()
 	}
 }


### PR DESCRIPTION
Use Close() interface call instead of Shutdown.
Use require instead of just assert.
Add test helper in kubernetes + kubernetes secrets config file to apply and remove to verify and test that provider.